### PR TITLE
Fix issues with multiple writes to UserDefaults

### DIFF
--- a/MASShortcut+Monitoring.m
+++ b/MASShortcut+Monitoring.m
@@ -38,7 +38,13 @@ void UninstallEventHandler();
 {
     if (monitor == nil) return;
     NSMutableDictionary *registeredHotKeys = MASRegisteredHotKeys();
+    MASShortcutHotKey *hotKey = [registeredHotKeys objectForKey: monitor];
     [registeredHotKeys removeObjectForKey:monitor];
+    if (hotKey)
+    {
+        [hotKey uninstallExisitingHotKey];
+        [hotKey release];
+    }
     if (registeredHotKeys.count == 0) {
         UninstallEventHandler();
     }


### PR DESCRIPTION
When using MASShortcut with MASPreferences, MASPreferences writes to UserDefaults multiple times when showing the preferences window, which causes multiple calls to `MASShortcut+UserDefaults#userDefaultsDidChange:`, which removes the current hotkey but queues the installation multiple times, so multiple hotkeys are installed.

However, we can't register two different handlers for a hotkey since we're using `kEventHotKeyExclusive`, so it causes the hotkeys to not work.

This PR ensures that only one install hotkey event happens with a timer and ensure that the old handler gets removed before attempting to install a new hotkey.
