### PR TITLE
Fixed 'shortcut' mistype

### DIFF
--- a/MASShortcutView.m
+++ b/MASShortcutView.m
@@ -169,7 +169,7 @@
         [self getShortcutRect:&shortcutRect hintRect:NULL];
         NSString *title = (self.recording
                            ? (_hinting
-                              ? NSLocalizedString(@"Use Old Shortuct", @"Cancel action button for non-empty shortcut in recording state")
+                              ? NSLocalizedString(@"Use Old Shortcut", @"Cancel action button for non-empty shortcut in recording state")
                               : (self.shortcutPlaceholder.length > 0
                                  ? self.shortcutPlaceholder
                                  : NSLocalizedString(@"Type New Shortcut", @"Non-empty shortcut button in recording state")))


### PR DESCRIPTION
It's not really important, but I fixed a mistype : I changed 'Shortuct' to 'Shortcut'.
