### PR TITLE
Disambiguate "the BSD license"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2012-2013, Vadim Shpakovski
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ If you like retain/release, please check out these forks: [heardrwt/MASShortcut]
 
 # Copyright
 
-MASShortcut is licensed under the BSD license.
+MASShortcut is licensed under the 2-clause BSD license.


### PR DESCRIPTION
[A Wikipedia article](http://en.wikipedia.org/wiki/BSD_licenses) says "the BSD license" means [the 3-clause BSD license](http://opensource.org/licenses/BSD-3-Clause), as quoted below,

> This [3-clause] version has been vetted as an Open source license by the OSI as the "The BSD License".[3]

while the link provided in the footnote now redirects to [the 2-clause BSD license](http://opensource.org/licenses/bsd-license.php).

Assuming you really meant the 2-clause license, this commit clarifies the term so that someone (including myself) can use this excellent library without hesitation.
