### PR TITLE
Added method for programatically setting a shortcut which is tied to a NSUserDefaults key

### DIFF
--- a/MASShortcut+UserDefaults.h
+++ b/MASShortcut+UserDefaults.h
@@ -4,5 +4,6 @@
 
 + (void)registerGlobalShortcutWithUserDefaultsKey:(NSString *)userDefaultsKey handler:(void (^)())handler;
 + (void)unregisterGlobalShortcutWithUserDefaultsKey:(NSString *)userDefaultsKey;
++ (void)setShortcut:(MASShortcut *)shortcut forUserDefaultsKey:(NSString *)userDefaultsKey;
 
 @end

--- a/MASShortcut+UserDefaults.m
+++ b/MASShortcut+UserDefaults.m
@@ -37,6 +37,13 @@
     [registeredHotKeys removeObjectForKey:userDefaultsKey];
 }
 
++ (void)setShortcut:(MASShortcut *)shortcut forUserDefaultsKey:(NSString *)userDefaultsKey
+{
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setObject:(shortcut.data ?: [NSKeyedArchiver archivedDataWithRootObject:nil]) forKey:userDefaultsKey];
+    [defaults synchronize];
+}
+
 @end
 
 #pragma mark -


### PR DESCRIPTION
Previously if you had a MASShortcutView, you couldn't programatically set it to some default value. For example on your app's first launch you might have wanted to initialize the global shortcut for a particular feature to some sane default, rather than leaving it empty, but still allowing the user to modify it using a typical MASShortcutView bound to a userDefaultsKey. Now you can.
