### PR TITLE
Replace deprecated NSRunCriticalAlertPanel with NSAlert

### DIFF
--- a/MASShortcutView.m
+++ b/MASShortcutView.m
@@ -380,12 +380,17 @@ void *kUserDataHint = &kUserDataHint;
                             [weakSelf activateEventMonitoring:NO];
                             NSString *format = NSLocalizedString(@"The key combination %@ cannot be used",
                                                                  @"Title for alert when shortcut is already used");
-                            NSRunCriticalAlertPanel([NSString stringWithFormat:format, shortcut], @"%@",
-                                                    NSLocalizedString(@"OK", @"Alert button when shortcut is already used"),
-                                                    nil, nil, error.localizedDescription);
-                            weakSelf.shortcutPlaceholder = nil;
-                            [weakSelf activateResignObserver:YES];
-                            [weakSelf activateEventMonitoring:YES];
+                            NSAlert* alert = [[NSAlert alloc]init];
+                            alert.messageText = [NSString stringWithFormat:format, shortcut];
+                            alert.informativeText = error.localizedDescription;
+                            alert.alertStyle = NSWarningAlertStyle;
+                            weakSelf.recording = NO;
+                            [alert beginSheetModalForWindow:self.window completionHandler:^(NSModalResponse returnCode) {
+                                weakSelf.shortcutPlaceholder = nil;
+                                [weakSelf activateResignObserver:YES];
+                                [weakSelf activateEventMonitoring:YES];
+                                weakSelf.recording = YES;
+                            }];
                         }
                         else {
                             weakSelf.shortcutValue = shortcut;


### PR DESCRIPTION
- Now using modern API
- The dialog is now shown as a modal sheet
- The alert style is changed to NSWarningAlertStyle
- NSCriticalAlertStyle was not required

Motivation for this was the string literal warning, which was resolved by iluuu1994. But I noticed that the API was deprecated so ported it to new NSAlert.
I decided to show as a sheet because the failure is very focused to a specific preferences window. NSCriticalAlertStyle was according to Apple's docs not appropriated. They designed it for _really_ critical things,  "for example, a “clean install” will erase all data on a volume".
