### PR TITLE
allow [MODIFIER]+ESC shortcuts

### DIFF
--- a/MASShortcutView.m
+++ b/MASShortcutView.m
@@ -359,7 +359,7 @@ void *kUserDataHint = &kUserDataHint;
                 weakSelf.recording = NO;
                 event = nil;
             }
-            else if (shortcut.keyCode == kVK_Escape) {
+            else if (shortcut.keyCode == kVK_Escape && !shortcut.modifierFlags) {
                 // Cancel recording
                 weakSelf.recording = NO;
                 event = nil;


### PR DESCRIPTION
only naked ESC without modifiers should cancel editing

http://discuss.binaryage.com/t/cant-change-activation-key-to-control-esc

repro case:
1. enter editing mode
2. press CTRL+ESC
3. editing gets canceled without shortcut change

expected behaviour: 
CTRL+ESC is set as new shortcut in step 3

tested with [TotalTerminal](http://totalterminal.binaryage.com/) codebase
