### PR TITLE
Fix "Parse issue: Semicolon before method body is ignored"

### DIFF
--- a/MASShortcut+UserDefaults.m
+++ b/MASShortcut+UserDefaults.m
@@ -25,7 +25,7 @@
     return shared;
 }
 
-+ (void)registerGlobalShortcutWithUserDefaultsKey:(NSString *)userDefaultsKey handler:(void (^)())handler;
++ (void)registerGlobalShortcutWithUserDefaultsKey:(NSString *)userDefaultsKey handler:(void (^)())handler
 {
     MASShortcutUserDefaultsHotKey *hotKey = [[MASShortcutUserDefaultsHotKey alloc] initWithUserDefaultsKey:userDefaultsKey handler:handler];
     [[self registeredUserDefaultsHotKeys] setObject:hotKey forKey:userDefaultsKey];


### PR DESCRIPTION
With Xcode 6.1, I am getting a "Parse issue: Semicolon before method body is ignored". This one line fix takes care of it.
