### PR TITLE
Flat button style

### DIFF
--- a/MASShortcutView.h
+++ b/MASShortcutView.h
@@ -6,7 +6,7 @@ typedef enum {
     MASShortcutViewAppearanceDefault = 0,  // Height = 19 px
     MASShortcutViewAppearanceTexturedRect, // Height = 25 px
     MASShortcutViewAppearanceRounded,      // Height = 43 px
-	MASShortcutViewAppearanceFlat
+    MASShortcutViewAppearanceFlat
 } MASShortcutViewAppearance;
 
 @interface MASShortcutView : NSView

--- a/MASShortcutView.m
+++ b/MASShortcutView.m
@@ -107,12 +107,12 @@
             _shortcutCell.bezelStyle = NSRoundedBezelStyle;
             break;
         }
-		case MASShortcutViewAppearanceFlat: {
-			self.wantsLayer = YES;
-			_shortcutCell.backgroundColor = [NSColor clearColor];
-			_shortcutCell.bordered = NO;
-			break;
-		}
+        case MASShortcutViewAppearanceFlat: {
+            self.wantsLayer = YES;
+            _shortcutCell.backgroundColor = [NSColor clearColor];
+            _shortcutCell.bordered = NO;
+            break;
+        }
     }
 }
 
@@ -182,16 +182,16 @@
             [_shortcutCell drawWithFrame:CGRectOffset(frame, 0.0, 1.0) inView:self];
             break;
         }
-		case MASShortcutViewAppearanceFlat: {
-			[_shortcutCell drawWithFrame:frame inView:self];
-			break;
-		}
+        case MASShortcutViewAppearanceFlat: {
+            [_shortcutCell drawWithFrame:frame inView:self];
+            break;
+        }
     }
 }
 
 - (void)drawRect:(CGRect)dirtyRect
 {
-	if (self.shortcutValue) {
+    if (self.shortcutValue) {
         [self drawInRect:self.bounds withTitle:MASShortcutChar(self.recording ? kMASShortcutGlyphEscape : kMASShortcutGlyphDeleteLeft)
                alignment:NSRightTextAlignment state:NSOffState];
         
@@ -237,8 +237,8 @@
     switch (self.appearance) {
         case MASShortcutViewAppearanceTexturedRect: hintButtonWidth += 2.0; break;
         case MASShortcutViewAppearanceRounded: hintButtonWidth += 3.0; break;
-		case MASShortcutViewAppearanceFlat: hintButtonWidth -= 8.0 - (_shortcutCell.font.pointSize - BUTTON_FONT_SIZE); break;
-		default: break;
+        case MASShortcutViewAppearanceFlat: hintButtonWidth -= 8.0 - (_shortcutCell.font.pointSize - BUTTON_FONT_SIZE); break;
+        default: break;
     }
     CGRectDivide(self.bounds, &hintRect, &shortcutRect, hintButtonWidth, CGRectMaxXEdge);
     if (shortcutRectRef)  *shortcutRectRef = shortcutRect;


### PR DESCRIPTION
Added a new button style named "flat", which hides the button border and background. This allows several shortcut controls to be placed into a table or other bordered view with a minimum of visual clutter.

![screen shot 2014-11-24 at 8 09 44 am](https://cloud.githubusercontent.com/assets/249247/5165353/5b4c3d24-73b1-11e4-8508-d576631887d6.png)
