### PR TITLE
Legacy OS X support down to 10.6 included

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+Unreleased yet
+    - Added support for older OS X versions down to 10.6 included.
+
 2.0.1 2015/1/9
     - Trivial Podspec fix.
 

--- a/Demo/MainMenu.xib
+++ b/Demo/MainMenu.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
@@ -655,19 +655,22 @@
                 <rect key="frame" x="0.0" y="0.0" width="393" height="129"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="536" customClass="MASShortcutView">
+                    <customView id="536" customClass="MASShortcutView">
                         <rect key="frame" x="142" y="90" width="158" height="19"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PG0-jh-Onh">
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="PG0-jh-Onh">
                         <rect key="frame" x="18" y="92" width="111" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Custom shortcut:" id="85u-1A-n7H">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zCi-ki-Uuh">
+                    <button id="zCi-ki-Uuh">
                         <rect key="frame" x="140" y="63" width="169" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Enable custom shortcut" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Y47-p3-sDa">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
@@ -676,16 +679,18 @@
                             <binding destination="rCO-Ve-DT5" name="value" keyPath="values.customShortcutEnabled" id="VjS-3V-VdA"/>
                         </connections>
                     </button>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KnS-ut-phz">
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="KnS-ut-phz">
                         <rect key="frame" x="18" y="65" width="111" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Options:" id="cUE-gA-heG">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="F4r-KM-wn9">
+                    <button id="F4r-KM-wn9">
                         <rect key="frame" x="140" y="43" width="235" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Enable hard-coded shortcut (⌘F2)" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="7gv-jN-44g">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
@@ -694,16 +699,18 @@
                             <binding destination="rCO-Ve-DT5" name="value" keyPath="values.hardcodedShortcutEnabled" id="dlZ-si-HeN"/>
                         </connections>
                     </button>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9fB-XS-8pK">
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="9fB-XS-8pK">
                         <rect key="frame" x="18" y="20" width="111" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Feedback:" id="Zbz-mV-NDc">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Aso-dH-W8I">
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Aso-dH-W8I">
                         <rect key="frame" x="140" y="20" width="211" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Press a shortcut to see feedback" id="Ckx-v7-e6x">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" red="0.37647062540054321" green="0.85098046064376831" blue="0.17647059261798859" alpha="1" colorSpace="deviceRGB"/>

--- a/Framework/MASHotKey.m
+++ b/Framework/MASHotKey.m
@@ -19,7 +19,7 @@ FourCharCode const MASHotKeySignature = 'MASS';
     EventHotKeyID hotKeyID = { .signature = MASHotKeySignature, .id = _carbonID };
 
     OSStatus status = RegisterEventHotKey([shortcut carbonKeyCode], [shortcut carbonFlags],
-        hotKeyID, GetEventDispatcherTarget(), kEventHotKeyExclusive, &_hotKeyRef);
+        hotKeyID, GetEventDispatcherTarget(), 0, &_hotKeyRef);
 
     if (status != noErr) {
         return nil;

--- a/Framework/MASHotKeyTests.m
+++ b/Framework/MASHotKeyTests.m
@@ -1,0 +1,15 @@
+#import "MASHotKey.h"
+
+@interface MASHotKeyTests : XCTestCase
+@end
+
+@implementation MASHotKeyTests
+
+- (void) testBasicFunctionality
+{
+    MASHotKey *hotKey = [MASHotKey registeredHotKeyWithShortcut:
+        [MASShortcut shortcutWithKeyCode:kVK_ANSI_H modifierFlags:NSCommandKeyMask|NSAlternateKeyMask]];
+    XCTAssertNotNil(hotKey, @"Register a simple Cmd-Alt-H hotkey.");
+}
+
+@end

--- a/Framework/MASShortcutMonitor.h
+++ b/Framework/MASShortcutMonitor.h
@@ -18,7 +18,7 @@
     Attempting to insert an already registered shortcut probably won’t work.
     It may burn your house or cut your fingers. You have been warned.
 */
-- (void) registerShortcut: (MASShortcut*) shortcut withAction: (dispatch_block_t) action;
+- (BOOL) registerShortcut: (MASShortcut*) shortcut withAction: (dispatch_block_t) action;
 - (BOOL) isShortcutRegistered: (MASShortcut*) shortcut;
 
 - (void) unregisterShortcut: (MASShortcut*) shortcut;

--- a/Framework/MASShortcutMonitor.m
+++ b/Framework/MASShortcutMonitor.m
@@ -45,11 +45,16 @@ static OSStatus MASCarbonEventCallback(EventHandlerCallRef, EventRef, void*);
 
 #pragma mark Registration
 
-- (void) registerShortcut: (MASShortcut*) shortcut withAction: (dispatch_block_t) action
+- (BOOL) registerShortcut: (MASShortcut*) shortcut withAction: (dispatch_block_t) action
 {
     MASHotKey *hotKey = [MASHotKey registeredHotKeyWithShortcut:shortcut];
-    [hotKey setAction:action];
-    [_hotKeys setObject:hotKey forKey:shortcut];
+    if (hotKey) {
+        [hotKey setAction:action];
+        [_hotKeys setObject:hotKey forKey:shortcut];
+        return YES;
+    } else {
+        return NO;
+    }
 }
 
 - (void) unregisterShortcut: (MASShortcut*) shortcut

--- a/Framework/MASShortcutMonitorTests.m
+++ b/Framework/MASShortcutMonitorTests.m
@@ -1,0 +1,23 @@
+#import "MASShortcutMonitor.h"
+
+@interface MASShortcutMonitorTests : XCTestCase
+@end
+
+@implementation MASShortcutMonitorTests
+
+- (void) testMonitorCreation
+{
+    XCTAssertNotNil([MASShortcutMonitor sharedMonitor], @"Create a shared shortcut monitor.");
+}
+
+- (void) testShortcutRegistration
+{
+    MASShortcutMonitor *monitor = [MASShortcutMonitor sharedMonitor];
+    MASShortcut *shortcut = [MASShortcut shortcutWithKeyCode:kVK_ANSI_H modifierFlags:NSCommandKeyMask|NSAlternateKeyMask];
+    XCTAssertTrue([monitor registerShortcut:shortcut withAction:NULL], @"Register a shortcut.");
+    XCTAssertTrue([monitor isShortcutRegistered:shortcut], @"Remember a previously registered shortcut.");
+    [monitor unregisterShortcut:shortcut];
+    XCTAssertFalse([monitor isShortcutRegistered:shortcut], @"Forget shortcut after unregistering.");
+}
+
+@end

--- a/Framework/MASShortcutView.m
+++ b/Framework/MASShortcutView.m
@@ -369,7 +369,7 @@ void *kUserDataHint = &kUserDataHint;
     
     static id eventMonitor = nil;
     if (shouldActivate) {
-        __weak MASShortcutView *weakSelf = self;
+        __unsafe_unretained MASShortcutView *weakSelf = self;
         NSEventMask eventMask = (NSKeyDownMask | NSFlagsChangedMask);
         eventMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:eventMask handler:^(NSEvent *event) {
 
@@ -450,7 +450,7 @@ void *kUserDataHint = &kUserDataHint;
     static id observer = nil;
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
     if (shouldActivate) {
-        __weak MASShortcutView *weakSelf = self;
+        __unsafe_unretained MASShortcutView *weakSelf = self;
         observer = [notificationCenter addObserverForName:NSWindowDidResignKeyNotification object:self.window
                                                 queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notification) {
                                                     weakSelf.recording = NO;

--- a/MASShortcut.podspec
+++ b/MASShortcut.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
                               'Tomáš Znamenáček' => 'tomas.znamenacek@gmail.com' }
 
   s.platform              = :osx
-  s.osx.deployment_target = "10.7"
+  s.osx.deployment_target = "10.6"
   s.source                = { :git => 'https://github.com/shpakovski/MASShortcut.git', :tag => '2.0.1' }
   s.source_files          = 'Framework/*.{h,m}'
   s.exclude_files         = 'Framework/*Tests.m'

--- a/MASShortcut.xcodeproj/project.pbxproj
+++ b/MASShortcut.xcodeproj/project.pbxproj
@@ -516,6 +516,7 @@
 				GCC_PREFIX_HEADER = Framework/Prefix.pch;
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = framework;
@@ -533,6 +534,7 @@
 				GCC_PREFIX_HEADER = Framework/Prefix.pch;
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = framework;
@@ -551,6 +553,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Demo/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -564,6 +567,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Demo/Prefix.pch;
 				INFOPLIST_FILE = Demo/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};

--- a/MASShortcut.xcodeproj/project.pbxproj
+++ b/MASShortcut.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D39DCA21A668A4400639145 /* MASHotKeyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D39DCA11A668A4400639145 /* MASHotKeyTests.m */; };
+		0D39DCA41A668E5500639145 /* MASShortcutMonitorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D39DCA31A668E5500639145 /* MASShortcutMonitorTests.m */; };
 		0D827CD71990D4420010B8EF /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D827CD61990D4420010B8EF /* Cocoa.framework */; };
 		0D827D251990D55E0010B8EF /* MASShortcut.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D827D1B1990D55E0010B8EF /* MASShortcut.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0D827D261990D55E0010B8EF /* MASShortcut.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D827D1C1990D55E0010B8EF /* MASShortcut.m */; };
@@ -64,6 +66,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0D39DCA11A668A4400639145 /* MASHotKeyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MASHotKeyTests.m; path = Framework/MASHotKeyTests.m; sourceTree = "<group>"; };
+		0D39DCA31A668E5500639145 /* MASShortcutMonitorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MASShortcutMonitorTests.m; path = Framework/MASShortcutMonitorTests.m; sourceTree = "<group>"; };
 		0D827CD31990D4420010B8EF /* MASShortcut.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MASShortcut.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D827CD61990D4420010B8EF /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		0D827CD91990D4420010B8EF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -231,8 +235,10 @@
 			children = (
 				0DC2F17419922798003A0131 /* MASHotKey.h */,
 				0DC2F17519922798003A0131 /* MASHotKey.m */,
+				0D39DCA11A668A4400639145 /* MASHotKeyTests.m */,
 				0D827DA319912D240010B8EF /* MASShortcutMonitor.h */,
 				0D827DA419912D240010B8EF /* MASShortcutMonitor.m */,
+				0D39DCA31A668E5500639145 /* MASShortcutMonitorTests.m */,
 			);
 			name = Monitoring;
 			sourceTree = "<group>";
@@ -419,6 +425,8 @@
 				0DC2F190199372B4003A0131 /* MASDictionaryTransformerTests.m in Sources */,
 				0D827D9419910B740010B8EF /* MASShortcutTests.m in Sources */,
 				0DC2F18919925F8F003A0131 /* MASShortcutBinderTests.m in Sources */,
+				0D39DCA21A668A4400639145 /* MASHotKeyTests.m in Sources */,
+				0D39DCA41A668E5500639145 /* MASShortcutMonitorTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Adds support for OS X down to 10.6 included. Mostly just two changes: removed Auto Layout support in the demo project and replaced `__weak` (unsupported on 10.6) with `__unsafe_unretained`. As both instances of `__weak` were used to prevent retain cycles, I think the changes should be safe.

@shpakovski, would you like to go over the changes before merging? You have already seen b9b1964, the two other commits are also very simple.