### PR TITLE
Added explicit instructions for use in Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ _observableKeyPath = [@"values." stringByAppendingString:kPreferenceGlobalShortc
                                                                 context:kGlobalShortcutContext];
 ```
 
+# Using in Swift projects
+
+  1. Install as a Pod using the latest CocoaPods with Swift support.
+  2. Create a bridging header file [using the instructions here](http://swiftalicio.us/2014/11/using-cocoapods-from-swift/)
+  3. Your bridging header file should contain the following [two](https://github.com/shpakovski/MASShortcut/issues/36) imports:
+        #import <Cocoa/Cocoa.h>
+        #import <MASShortcut/Shortcut.h>
+
 # Non-ARC Version
 
 If you like retain/release, please check out these forks: [heardrwt/MASShortcut](https://github.com/heardrwt/MASShortcut) and [chendo/MASShortcut](https://github.com/chendo/MASShortcut). However, the preferred way is to enable the `-fobjc-arc` in Xcode source options.


### PR DESCRIPTION
The explicit Cocoa import had tripped me up. Would be good to save someone the same hassle.