### PR TITLE
Not declaring MASShortcutGlyph as a variable in the header

### DIFF
--- a/Framework/MASKeyCodes.h
+++ b/Framework/MASKeyCodes.h
@@ -21,7 +21,7 @@ enum {
     kMASShortcutGlyphPadClear = 0x2327,
     kMASShortcutGlyphNorthwestArrow = 0x2196,
     kMASShortcutGlyphSoutheastArrow = 0x2198,
-} MASShortcutGlyph;
+};
 
 NS_INLINE NSString* NSStringFromMASKeyCode(unsigned short ch)
 {


### PR DESCRIPTION
Not declaring this enum variable in the header prevents a duplicate symbols error:
```
duplicate symbol _MASShortcutGlyph in:
    /Users/pfandrade/Library/Developer/Xcode/DerivedData/Secrets-epbzwbmqvrgyjjgumbwsgmobfykd/Build/Intermediates/Secrets.build/Debug/Secrets Helper.build/Objects-normal/x86_64/Constants.o
    /Users/pfandrade/Library/Developer/Xcode/DerivedData/Secrets-epbzwbmqvrgyjjgumbwsgmobfykd/Build/Intermediates/Secrets.build/Debug/Secrets Helper.build/Objects-normal/x86_64/AppDelegate.o
ld: 1 duplicate symbol for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```