### PR TITLE
fixes localized strings when using CocoaPods

### DIFF
--- a/Framework/MASLocalization.m
+++ b/Framework/MASLocalization.m
@@ -2,6 +2,12 @@
 #import "MASShortcut.h"
 
 NSString *MASLocalizedString(NSString *key, NSString *comment) {
-    NSBundle *frameworkBundle = [NSBundle bundleForClass:[MASShortcut class]];
+    NSBundle *frameworkBundle = nil;
+#ifdef COCOAPODS
+    NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:@"MASShortcut" withExtension:@"bundle"];
+    frameworkBundle = [NSBundle bundleWithURL:bundleURL];
+#else
+    frameworkBundle = [NSBundle bundleForClass:[MASShortcut class]];
+#endif
     return [frameworkBundle localizedStringForKey:key value:@"XXX" table:@"Localizable"];
 }

--- a/MASShortcut.podspec
+++ b/MASShortcut.podspec
@@ -1,3 +1,4 @@
+# coding: utf-8
 Pod::Spec.new do |s|
   s.name                  = 'MASShortcut'
   s.version               = '2.3.1'
@@ -14,4 +15,5 @@ Pod::Spec.new do |s|
   s.exclude_files         = 'Framework/*Tests.m'
   s.osx.frameworks        = 'Carbon', 'AppKit'
   s.requires_arc          = true
+  s.osx.resource_bundles  = { 'MASShortcut' => ['*.lproj'] }
 end


### PR DESCRIPTION
Puts strings inside a MASShortcut resource bundle, and looks for locallized strings inside that bundle when used as a CocoaPod.

I tested this is a new vanilla project using CocoaPods and my local repo.

Fixes the issue I raised in #74.