### PR TITLE
Minor fixes and Swift improvements

### DIFF
--- a/Framework/MASKeyCodes.h
+++ b/Framework/MASKeyCodes.h
@@ -3,7 +3,7 @@
 #import "MASKeyMasks.h"
 
 // These glyphs are missed in Carbon.h
-enum {
+typedef NS_ENUM(unsigned short, kMASShortcutGlyph) {
     kMASShortcutGlyphEject = 0x23CF,
     kMASShortcutGlyphClear = 0x2715,
     kMASShortcutGlyphDeleteLeft = 0x232B,

--- a/Framework/MASShortcutView.h
+++ b/Framework/MASShortcutView.h
@@ -2,12 +2,12 @@
 
 extern NSString *const MASShortcutBinding;
 
-typedef enum {
+typedef NS_ENUM(NSInteger, MASShortcutViewStyle) {
     MASShortcutViewStyleDefault = 0,  // Height = 19 px
     MASShortcutViewStyleTexturedRect, // Height = 25 px
     MASShortcutViewStyleRounded,      // Height = 43 px
     MASShortcutViewStyleFlat
-} MASShortcutViewStyle;
+};
 
 @interface MASShortcutView : NSView
 

--- a/Framework/MASShortcutView.m
+++ b/Framework/MASShortcutView.m
@@ -386,7 +386,7 @@ void *kUserDataHint = &kUserDataHint;
     else if (data == kUserDataHint) {
         return MASLocalizedString(@"Delete shortcut", @"Tooltip for hint button near the non-empty shortcut");
     }
-    return nil;
+    return @"";
 }
 
 #pragma mark - Event monitoring


### PR DESCRIPTION
This PR introduces two changes:

- Improves Swift syntax when dealing with enumerations in the project by using `typedef NS_ENUM`
- Fixes an expected non-null return string from the NSToolTip method implemented in `MASShortcutView` 