### PR TITLE
Brazilian Portuguese localization

### DIFF
--- a/Demo/pt.lproj/Localizable.strings
+++ b/Demo/pt.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+﻿/* Feedback that’s displayed when user presses the sample shortcut. */
+"Shortcut pressed!" = "Atalho pressionado!";
+

--- a/MASShortcut.xcodeproj/project.pbxproj
+++ b/MASShortcut.xcodeproj/project.pbxproj
@@ -125,6 +125,8 @@
 		0DC2F19619938EFA003A0131 /* MASShortcutView+Bindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "MASShortcutView+Bindings.h"; path = "Framework/MASShortcutView+Bindings.h"; sourceTree = "<group>"; };
 		0DC2F19719938EFA003A0131 /* MASShortcutView+Bindings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "MASShortcutView+Bindings.m"; path = "Framework/MASShortcutView+Bindings.m"; sourceTree = "<group>"; };
 		0DEDAA021C6BB479001605F5 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		57B25C2D1E78E06D0061A9EC /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
+		57B25C2E1E78E06D0061A9EC /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6EA6034E1CBF822000A3ED9C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6EA6034F1CBF822800A3ED9C /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6EA603501CBF822D00A3ED9C /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -401,6 +403,7 @@
 				ko,
 				ru,
 				nl,
+				pt,
 			);
 			mainGroup = 0D827CC91990D4420010B8EF;
 			productRefGroup = 0D827CD41990D4420010B8EF /* Products */;
@@ -506,6 +509,7 @@
 				6EA6034F1CBF822800A3ED9C /* ko */,
 				6EA603501CBF822D00A3ED9C /* ru */,
 				6EA603511CBF823600A3ED9C /* nl */,
+				57B25C2D1E78E06D0061A9EC /* pt */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -526,6 +530,7 @@
 				0D2CAB241B834467005431FC /* cs */,
 				ED8737791BCE459800BB1716 /* ja */,
 				0DEDAA021C6BB479001605F5 /* de */,
+				57B25C2E1E78E06D0061A9EC /* pt */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/pt.lproj/Localizable.strings
+++ b/pt.lproj/Localizable.strings
@@ -1,0 +1,47 @@
+﻿/* Cancel action button in recording state */
+"Cancel" = "Cancelar";
+
+/* Tooltip for non-empty shortcut button */
+"Click to record new shortcut" ="Clique para gravar o atalho";
+
+/* Tooltip for hint button near the non-empty shortcut */
+"Delete shortcut" = "Apagar atalho";
+
+/* VoiceOver title */
+"keyboard shortcut" = "atalho de teclado";
+
+/* Alert button when shortcut is already used */
+"OK" = "OK";
+
+/* Empty shortcut button in normal state */
+"Record Shortcut" = "Gravar Atalho";
+
+/* VoiceOver: Shortcut cleared */
+"Shortcut cleared" = "Atalho limpo";
+
+/* VoiceOver: Shortcut set */
+"Shortcut set" = "Atalho definido";
+
+/* Shortcut glyph name for SPACE key */
+"Space" = "Espaço";
+
+/* Title for alert when shortcut is already used */
+"The key combination %@ cannot be used" = "A combinação de teclas “%@” não pode ser usada";
+
+/* Message for alert when shortcut is already used by the system */
+"This combination cannot be used because it is already used by a system-wide keyboard shortcut.\nIf you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences." = "Esta combinação não pode ser usada porque ela já é usada por um atalho global do sistema.\nA maioria dos atalhos pode ser alterada no painel Teclado das Preferências do Sistema, caso realmente deseje usar esta combinação.";
+
+/* Message for alert when shortcut is already used */
+"This shortcut cannot be used because it is already used by the menu item ‘%@’." = "Este atalho não pode ser usado porque ele já é usado pelo item de menu “%@”.";
+
+/* VoiceOver shortcut help */
+"To record a new shortcut, click this button, and then type the new shortcut, or press delete to clear an existing shortcut." = "Para gravar um atalho novo, clique neste botão e digite o novo atalho ou pressione apagar para limpar um atalho existente.";
+
+/* Non-empty shortcut button in recording state */
+"Type New Shortcut" = "Digite o atalho";
+
+/* Empty shortcut button in recording state */
+"Type Shortcut" = "Digite o atalho";
+
+/* Cancel action button for non-empty shortcut in recording state */
+"Use Old Shortcut" = "Usar atalho antigo";


### PR DESCRIPTION
Brazilian Portuguese localization taking in consideration space constraints usually imposed by shortcut recording interfaces.

Please note that Apple has been using pt.lproj for Brazilian Portuguese and pt-PT for European Portuguese, thus the locale creation on Xcode.

Also note that in the string: "… most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences", the correct path should be Keyboard, as this pane has been split in two for a while on macOS.