### PR TITLE
kVK_ANSI_KeypadMinus value adjustment.

### DIFF
--- a/Framework/MASShortcut.m
+++ b/Framework/MASShortcut.m
@@ -132,7 +132,7 @@ static NSString *const MASShortcutModifierFlags = @"ModifierFlags";
         case kVK_ANSI_KeypadClear: return NSStringFromMASKeyCode(kMASShortcutGlyphPadClear);
         case kVK_ANSI_KeypadDivide: return @"/";
         case kVK_ANSI_KeypadEnter: return NSStringFromMASKeyCode(kMASShortcutGlyphReturn);
-        case kVK_ANSI_KeypadMinus: return @"–";
+        case kVK_ANSI_KeypadMinus: return @"-";
         case kVK_ANSI_KeypadEquals: return @"=";
             
         // Hardcode


### PR DESCRIPTION
kVK_ANSI_KeypadMinus should return regular HYPHEN-MINUS (45) symbol instead of provided EN DASH (8211).