### PR TITLE
Replace commas with semicolons to separate statements

### DIFF
--- a/Framework/MASShortcutView.m
+++ b/Framework/MASShortcutView.m
@@ -364,10 +364,12 @@ void *kUserDataHint = &kUserDataHint;
 - (void)resetToolTips
 {
     if (_shortcutToolTipTag) {
-        [self removeToolTip:_shortcutToolTipTag], _shortcutToolTipTag = 0;
+        [self removeToolTip:_shortcutToolTipTag];
+        _shortcutToolTipTag = 0;
     }
     if (_hintToolTipTag) {
-        [self removeToolTip:_hintToolTipTag], _hintToolTipTag = 0;
+        [self removeToolTip:_hintToolTipTag];
+        _hintToolTipTag = 0;
     }
     
     if ((self.shortcutValue == nil) || self.recording || !self.enabled) return;


### PR DESCRIPTION
I've updated the code as suggested by Xcode 9; of particular note, there a couple of commas that should be semicolons.