### PR TITLE
Remove implicit retain of self in eventMonitor block

### DIFF
--- a/Framework/MASShortcutView.m
+++ b/Framework/MASShortcutView.m
@@ -432,10 +432,10 @@ void *kUserDataHint = &kUserDataHint;
             else {
                 // Verify possible shortcut
                 if (shortcut.keyCodeString.length > 0) {
-                    if ([_shortcutValidator isShortcutValid:shortcut]) {
+                    if ([weakSelf.shortcutValidator isShortcutValid:shortcut]) {
                         // Verify that shortcut is not used
                         NSString *explanation = nil;
-                        if ([_shortcutValidator isShortcutAlreadyTakenBySystem:shortcut explanation:&explanation]) {
+                        if ([weakSelf.shortcutValidator isShortcutAlreadyTakenBySystem:shortcut explanation:&explanation]) {
                             // Prevent cancel of recording when Alert window is key
                             [weakSelf activateResignObserver:NO];
                             [weakSelf activateEventMonitoring:NO];


### PR DESCRIPTION
In `MASShortcutView.m`, `-activateEventMonitoring:` was implicitly retaining self in two places by using the `_shortcutValidator` variable. In certain cases, this caused the control to fail to recognize new keystrokes.

To see the problem in action, run the attached sample project. Click shortcut view, then press command-w to close the window (before a shortcut has been set). Open a new document window and click the shortcut view there - at this point modifier keys will not register in the view.

The reason seems to be that because self is retained buy the block, when the new control calls `-activateEventMonitoring:`, the old block and therefore the old self is dealloc'ed, which causes `activateEventMonitoring:` to be called a second time with `NO`.

[TestApp.zip](https://github.com/shpakovski/MASShortcut/files/2014501/TestApp.zip)