### PR TITLE
Make it possible to turn off shortcut validation

### DIFF
--- a/Framework/MASShortcutView.m
+++ b/Framework/MASShortcutView.m
@@ -466,7 +466,7 @@ void *kUserDataHint = &kUserDataHint;
             else {
                 // Verify possible shortcut
                 if (shortcut.keyCodeString.length > 0) {
-                    if ([weakSelf.shortcutValidator isShortcutValid:shortcut]) {
+                    if (!weakSelf.shortcutValidator || [weakSelf.shortcutValidator isShortcutValid:shortcut]) {
                         // Verify that shortcut is not used
                         NSString *explanation = nil;
                         if ([weakSelf.shortcutValidator isShortcutAlreadyTakenBySystem:shortcut explanation:&explanation]) {


### PR DESCRIPTION
Previously, setting a nil `shortcutValidator` on `MASShortcutView` would lead to all shortcuts considered invalid. I think it’s better the other way around, where setting “no validator” means the caller wants no validation done at all.

(I actually have a use case for this. Under normal circumstances, recording keys with no validation doesn’t have much sense, but I use `MASShortcutView` to record shortcuts that will be used in a different context, in the browser.)