### PR TITLE
Use more specific types for -keyCode and -modifierFlags

### DIFF
--- a/Framework/MASShortcut.h
+++ b/Framework/MASShortcut.h
@@ -16,14 +16,14 @@
  Hardware independent, same as in `NSEvent`. See `Events.h` in the HIToolbox
  framework for a complete list, or Command-click this symbol: `kVK_ANSI_A`.
 */
-@property (nonatomic, readonly) NSUInteger keyCode;
+@property (nonatomic, readonly) NSInteger keyCode;
 
 /**
  Cocoa keyboard modifier flags.
 
  Same as in `NSEvent`: `NSCommandKeyMask`, `NSAlternateKeyMask`, etc.
 */
-@property (nonatomic, readonly) NSUInteger modifierFlags;
+@property (nonatomic, readonly) NSEventModifierFlags modifierFlags;
 
 /**
  Same as `keyCode`, just a different type.
@@ -68,8 +68,8 @@
 */
 @property (nonatomic, readonly) NSString *modifierFlagsString;
 
-- (instancetype)initWithKeyCode:(NSUInteger)code modifierFlags:(NSUInteger)flags;
-+ (instancetype)shortcutWithKeyCode:(NSUInteger)code modifierFlags:(NSUInteger)flags;
+- (instancetype)initWithKeyCode:(NSInteger)code modifierFlags:(NSEventModifierFlags)flags;
++ (instancetype)shortcutWithKeyCode:(NSInteger)code modifierFlags:(NSEventModifierFlags)flags;
 
 /**
  Creates a new shortcut from an `NSEvent` object.

--- a/Framework/MASShortcut.m
+++ b/Framework/MASShortcut.m
@@ -8,7 +8,7 @@ static NSString *const MASShortcutModifierFlags = @"ModifierFlags";
 
 #pragma mark Initialization
 
-- (instancetype)initWithKeyCode:(NSUInteger)code modifierFlags:(NSUInteger)flags
+- (instancetype)initWithKeyCode:(NSInteger)code modifierFlags:(NSEventModifierFlags)flags
 {
     self = [super init];
     if (self) {
@@ -18,7 +18,7 @@ static NSString *const MASShortcutModifierFlags = @"ModifierFlags";
     return self;
 }
 
-+ (instancetype)shortcutWithKeyCode:(NSUInteger)code modifierFlags:(NSUInteger)flags
++ (instancetype)shortcutWithKeyCode:(NSInteger)code modifierFlags:(NSEventModifierFlags)flags
 {
     return [[self alloc] initWithKeyCode:code modifierFlags:flags];
 }
@@ -210,7 +210,7 @@ static NSString *const MASShortcutModifierFlags = @"ModifierFlags";
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
-    [coder encodeInteger:(self.keyCode != NSNotFound ? (NSInteger)self.keyCode : - 1) forKey:MASShortcutKeyCode];
+    [coder encodeInteger:(self.keyCode != NSNotFound ? self.keyCode : - 1) forKey:MASShortcutKeyCode];
     [coder encodeInteger:(NSInteger)self.modifierFlags forKey:MASShortcutModifierFlags];
 }
 
@@ -219,7 +219,7 @@ static NSString *const MASShortcutModifierFlags = @"ModifierFlags";
     self = [super init];
     if (self) {
         NSInteger code = [decoder decodeIntegerForKey:MASShortcutKeyCode];
-        _keyCode = (code < 0 ? NSNotFound : (NSUInteger)code);
+        _keyCode = (code < 0) ? NSNotFound : code;
         _modifierFlags = [decoder decodeIntegerForKey:MASShortcutModifierFlags];
     }
     return self;

--- a/Framework/MASShortcutValidator.m
+++ b/Framework/MASShortcutValidator.m
@@ -15,8 +15,8 @@
 
 - (BOOL) isShortcutValid: (MASShortcut*) shortcut
 {
-    NSUInteger keyCode = [shortcut keyCode];
-    NSUInteger modifiers = [shortcut modifierFlags];
+    NSInteger keyCode = [shortcut keyCode];
+    NSEventModifierFlags modifiers = [shortcut modifierFlags];
 
     // Allow any function key with any combination of modifiers
     BOOL includesFunctionKey = ((keyCode == kVK_F1) || (keyCode == kVK_F2) || (keyCode == kVK_F3) || (keyCode == kVK_F4) ||
@@ -53,7 +53,7 @@
 - (BOOL) isShortcut: (MASShortcut*) shortcut alreadyTakenInMenu: (NSMenu*) menu explanation: (NSString**) explanation
 {
     NSString *keyEquivalent = [shortcut keyCodeStringForKeyEquivalent];
-    NSUInteger flags = [shortcut modifierFlags];
+    NSEventModifierFlags flags = [shortcut modifierFlags];
 
     for (NSMenuItem *menuItem in menu.itemArray) {
         if (menuItem.hasSubmenu && [self isShortcut:shortcut alreadyTakenInMenu:[menuItem submenu] explanation:explanation]) return YES;
@@ -91,7 +91,7 @@
             CFNumberRef flags = CFDictionaryGetValue(hotKeyInfo, kHISymbolicHotKeyModifiers);
             CFNumberRef enabled = CFDictionaryGetValue(hotKeyInfo, kHISymbolicHotKeyEnabled);
 
-            if (([(__bridge NSNumber *)code unsignedIntegerValue] == [shortcut keyCode]) &&
+            if (([(__bridge NSNumber *)code integerValue] == [shortcut keyCode]) &&
                 ([(__bridge NSNumber *)flags unsignedIntegerValue] == [shortcut carbonFlags]) &&
                 ([(__bridge NSNumber *)enabled boolValue])) {
 


### PR DESCRIPTION
It was initially suggested in #103 that we change -keyCode to NSInteger and -modifierFlags to NSEventModifierFlags, but the changes were mixed with other unrelated stuff and the discussion died out. But the main point of the proposed patch was good, the suggested types make the code work better in Swift, apart from other things.