### PR TITLE
Fix CocoaPods build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: objective-c
 script:
-    xcodebuild -scheme MASShortcut build test
+    - xcodebuild -scheme MASShortcut build test
+    - bundle exec pod lib lint

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,6 +1,6 @@
 # Backward Compatibility
 
-Please note that this framework supports older OS X versions down to 10.6. When changing the code, be careful not to call any API functions not available in 10.6 or call them conditionally, only where supported.
+Please note that this framework supports older OS X versions down to 10.10. When changing the code, be careful not to call any API functions not available in 10.10 or call them conditionally, only where supported.
 
 # Commit Messages
 

--- a/MASShortcut.podspec
+++ b/MASShortcut.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
                               'Tomáš Znamenáček' => 'tomas.znamenacek@gmail.com' }
 
   s.platform              = :osx
-  s.osx.deployment_target = "10.6"
+  s.osx.deployment_target = "10.10"
   s.source                = { :git => 'https://github.com/shpakovski/MASShortcut.git', :tag => s.version }
   s.source_files          = 'Framework/**/*.{h,m}'
   s.exclude_files         = 'Framework/**/*Tests.m'

--- a/MASShortcut.xcodeproj/project.pbxproj
+++ b/MASShortcut.xcodeproj/project.pbxproj
@@ -665,7 +665,6 @@
 				GCC_PREFIX_HEADER = Framework/Prefix.pch;
 				INFOPLIST_FILE = Framework/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MODULEMAP_FILE = Framework/MASShortcut.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.shpakovski.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -688,7 +687,6 @@
 				GCC_PREFIX_HEADER = Framework/Prefix.pch;
 				INFOPLIST_FILE = Framework/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MODULEMAP_FILE = Framework/MASShortcut.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.shpakovski.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Features:
 * Can be configured to be compatible with Shortcut Recorder
 * Can be installed both through CocoaPods and as a Git submodule
 * Mac App Store friendly
-* Works on OS X 10.6 and up
+* Works on OS X 10.10 and up
 * Hacking-friendly codebase covered with tests
 
 Partially done:


### PR DESCRIPTION
There was a trivial error in the podspec that prevented the CocoaPods build from succeeding (see #131), now we should be back in the game. I have also tried adding a CocoaPods linter pass into Travis config to make sure we keep the CocoaPods build working.