### PR TITLE
Add nullability annotations

### DIFF
--- a/Framework/Model/MASShortcut.h
+++ b/Framework/Model/MASShortcut.h
@@ -45,7 +45,7 @@
  to be precise) the `keyCodeString` is `2` on the US keyboard, but `ě` when
  the Czech keyboard layout is active. See the spec for details.
 */
-@property (nonatomic, readonly) NSString *keyCodeString;
+@property (nonatomic, readonly, nullable) NSString *keyCodeString;
 
 /**
  A key-code string used in key equivalent matching.
@@ -61,21 +61,21 @@
  that’s always displayed as `^U`. So the `keyCodeString` returns `Г`
  and `keyCodeStringForKeyEquivalent` returns `U`.
 */
-@property (nonatomic, readonly) NSString *keyCodeStringForKeyEquivalent;
+@property (nonatomic, readonly, nullable) NSString *keyCodeStringForKeyEquivalent;
 
 /**
  A string representing the shortcut modifiers, like the `⌘` in `⌘5`.
 */
-@property (nonatomic, readonly) NSString *modifierFlagsString;
+@property (nonatomic, readonly, nonnull) NSString *modifierFlagsString;
 
-- (instancetype)initWithKeyCode:(NSInteger)code modifierFlags:(NSEventModifierFlags)flags;
-+ (instancetype)shortcutWithKeyCode:(NSInteger)code modifierFlags:(NSEventModifierFlags)flags;
+- (nonnull instancetype)initWithKeyCode:(NSInteger)code modifierFlags:(NSEventModifierFlags)flags;
++ (nonnull instancetype)shortcutWithKeyCode:(NSInteger)code modifierFlags:(NSEventModifierFlags)flags;
 
 /**
  Creates a new shortcut from an `NSEvent` object.
 
  This is just a convenience initializer that reads the key code and modifiers from an `NSEvent`.
 */
-+ (instancetype)shortcutWithEvent:(NSEvent *)anEvent;
++ (nonnull instancetype)shortcutWithEvent:(nonnull NSEvent *)anEvent;
 
 @end

--- a/Framework/UI/MASShortcutView+Bindings.h
+++ b/Framework/UI/MASShortcutView+Bindings.h
@@ -17,9 +17,9 @@
 */
 @interface MASShortcutView (Bindings)
 
-@property(copy) NSString *associatedUserDefaultsKey;
+@property(copy, nullable) NSString *associatedUserDefaultsKey;
 
-- (void) setAssociatedUserDefaultsKey: (NSString*) newKey withTransformer: (NSValueTransformer*) transformer;
-- (void) setAssociatedUserDefaultsKey: (NSString*) newKey withTransformerName: (NSString*) transformerName;
+- (void) setAssociatedUserDefaultsKey: (nullable NSString*) newKey withTransformer: (nullable NSValueTransformer*) transformer;
+- (void) setAssociatedUserDefaultsKey: (nullable NSString*) newKey withTransformerName: (nullable NSString*) transformerName;
 
 @end

--- a/Framework/UI/MASShortcutView.h
+++ b/Framework/UI/MASShortcutView.h
@@ -1,6 +1,6 @@
 @class MASShortcut, MASShortcutValidator;
 
-extern NSString *const MASShortcutBinding;
+extern NSString * _Nonnull const MASShortcutBinding;
 
 typedef NS_ENUM(NSInteger, MASShortcutViewStyle) {
     MASShortcutViewStyleDefault = 0,  // Height = 19 px
@@ -11,15 +11,15 @@ typedef NS_ENUM(NSInteger, MASShortcutViewStyle) {
 
 @interface MASShortcutView : NSView
 
-@property (nonatomic, strong) MASShortcut *shortcutValue;
-@property (nonatomic, strong) MASShortcutValidator *shortcutValidator;
+@property (nonatomic, strong, nullable) MASShortcut *shortcutValue;
+@property (nonatomic, strong, nullable) MASShortcutValidator *shortcutValidator;
 @property (nonatomic, getter = isRecording) BOOL recording;
 @property (nonatomic, getter = isEnabled) BOOL enabled;
-@property (nonatomic, copy) void (^shortcutValueChange)(MASShortcutView *sender);
+@property (nonatomic, copy, nullable) void (^shortcutValueChange)(MASShortcutView * _Nonnull sender);
 @property (nonatomic, assign) MASShortcutViewStyle style;
 
 /// Returns custom class for drawing control.
-+ (Class)shortcutCellClass;
++ (nonnull Class)shortcutCellClass;
 
 - (void)setAcceptsFirstResponder:(BOOL)value;
 


### PR DESCRIPTION
These are some basic annotations (see #102) that mostly make it easier to use MASShortcut from Swift, since the properties no longer show up as suspect implicitly unwrapped optionals. I did not annotate all the classes, just the main ones that most people will use.