### PR TITLE
Added regularSquare style to MASShortcutView

### DIFF
--- a/Framework/UI/MASShortcutView.h
+++ b/Framework/UI/MASShortcutView.h
@@ -6,7 +6,8 @@ typedef NS_ENUM(NSInteger, MASShortcutViewStyle) {
     MASShortcutViewStyleDefault = 0,  // Height = 19 px
     MASShortcutViewStyleTexturedRect, // Height = 25 px
     MASShortcutViewStyleRounded,      // Height = 43 px
-    MASShortcutViewStyleFlat
+    MASShortcutViewStyleFlat,
+    MASShortcutViewStyleRegularSquare
 };
 
 @interface MASShortcutView : NSView

--- a/Framework/UI/MASShortcutView.m
+++ b/Framework/UI/MASShortcutView.m
@@ -114,6 +114,10 @@ static const CGFloat MASButtonFontSize = 11;
             _shortcutCell.bordered = NO;
             break;
         }
+        case MASShortcutViewStyleRegularSquare: {
+            _shortcutCell.bezelStyle = NSBezelStyleRegularSquare;
+            break;
+        }
     }
 }
 
@@ -201,24 +205,21 @@ static const CGFloat MASButtonFontSize = 11;
     _shortcutCell.state = state;
     _shortcutCell.enabled = self.enabled;
 
+    CGFloat yOffset;
+
     switch (_style) {
-        case MASShortcutViewStyleDefault: {
-            [_shortcutCell drawWithFrame:frame inView:self];
+        case MASShortcutViewStyleTexturedRect:
+        case MASShortcutViewStyleRounded:
+        case MASShortcutViewStyleRegularSquare: {
+            yOffset = 1.0;
             break;
         }
-        case MASShortcutViewStyleTexturedRect: {
-            [_shortcutCell drawWithFrame:CGRectOffset(frame, 0.0, 1.0) inView:self];
+        default:
+            yOffset = 0.0;
             break;
-        }
-        case MASShortcutViewStyleRounded: {
-            [_shortcutCell drawWithFrame:CGRectOffset(frame, 0.0, 1.0) inView:self];
-            break;
-        }
-        case MASShortcutViewStyleFlat: {
-            [_shortcutCell drawWithFrame:frame inView:self];
-            break;
-        }
     }
+
+    [_shortcutCell drawWithFrame:CGRectOffset(frame, 0.0, yOffset) inView:self];
 }
 
 - (void)drawRect:(CGRect)dirtyRect


### PR DESCRIPTION
NSBezelStyleRegularSquare is drawn properly on macOS 11.0.
I'd use this style as a quick fix for #149. 

macOS **11.0**:
<img width="465" alt="macOS 11.0" src="https://user-images.githubusercontent.com/1675298/96164579-132eb700-0f24-11eb-85a7-58c9a4202d2e.png">

macOS **10.15**:
Not ideal, might want to conditionally use another style before 11.0.
<img width="454" alt="macOS 10.15" src="https://user-images.githubusercontent.com/1675298/96164658-348fa300-0f24-11eb-8dee-c0be1c4067a8.png">

