### PR TITLE
Make MASShortcutView an accessibility element. #152

### DIFF
--- a/Framework/UI/MASShortcutView.m
+++ b/Framework/UI/MASShortcutView.m
@@ -580,6 +580,11 @@ void *kUserDataHint = &kUserDataHint;
 
 #pragma mark - Accessibility
 
+- (BOOL)isAccessibilityElement
+{
+    return YES;
+}
+
 - (NSString *)accessibilityHelp
 {
     return MASLocalizedString(@"To record a new shortcut, click this button, and then type the"


### PR DESCRIPTION
This makes it possible to select it using VoiceOver and prevents the system from ignoring the accessibility notification that's posted when the shortcut is changed.