### PR TITLE
Fix typo from replacement of deprecated constants

### DIFF
--- a/Framework/UI/MASShortcutView.m
+++ b/Framework/UI/MASShortcutView.m
@@ -243,7 +243,7 @@ static const CGFloat MASButtonFontSize = 11;
                                  ? self.shortcutPlaceholder
                                  : MASLocalizedString(@"Type New Shortcut", @"Non-empty shortcut button in recording state")))
                            : _shortcutValue ? _shortcutValue.description : @"");
-        [self drawInRect:shortcutRect withTitle:title alignment:NSTextAlignmentCenter state:self.isRecording ? NSControlStateValueOff: NSControlStateValueOff];
+        [self drawInRect:shortcutRect withTitle:title alignment:NSTextAlignmentCenter state:self.isRecording ? NSControlStateValueOn : NSControlStateValueOff];
     }
     else {
         if (self.recording)


### PR DESCRIPTION
A small typo was introduced recently when deprecated constants were replaced with their new names. An instance of `NSOnState` was accidentally converted to `NSControlStateValueOff` instead of `NSControlStateValueOn`.