### PR TITLE
Support for generating correct keyEquivalents for function keys.

### DIFF
--- a/Framework/Model/MASKeyCodes.h
+++ b/Framework/Model/MASKeyCodes.h
@@ -23,6 +23,15 @@ typedef NS_ENUM(unsigned short, kMASShortcutGlyph) {
     kMASShortcutGlyphSoutheastArrow = 0x2198,
 };
 
+// The missing function key definitions for `NS*FunctionKey`s
+typedef NS_ENUM(unsigned short, kMASShortcutFuctionKey) {
+    kMASShortcutEscapeFunctionKey = 0x001B,
+    kMASShortcutDeleteFunctionKey = 0x0008,
+    kMASShortcutSpaceFunctionKey = 0x0020,
+    kMASShortcutReturnFunctionKey = 0x000D,
+    kMASShortcutTabFunctionKey = 0x0009,
+};
+
 NS_INLINE NSString* NSStringFromMASKeyCode(unsigned short ch)
 {
     return [NSString stringWithFormat:@"%C", ch];

--- a/Framework/Model/MASShortcut.m
+++ b/Framework/Model/MASShortcut.m
@@ -49,10 +49,6 @@ static NSString *const MASShortcutModifierFlags = @"ModifierFlags";
 {
     NSString *keyCodeString = self.keyCodeString;
 
-    if (keyCodeString.length <= 1) {
-        return keyCodeString.lowercaseString;
-    }
-
     switch (self.keyCode) {
         case kVK_F1: return NSStringFromMASKeyCode(NSF1FunctionKey);
         case kVK_F2: return NSStringFromMASKeyCode(NSF2FunctionKey);
@@ -73,9 +69,24 @@ static NSString *const MASShortcutModifierFlags = @"ModifierFlags";
         case kVK_F17: return NSStringFromMASKeyCode(NSF17FunctionKey);
         case kVK_F18: return NSStringFromMASKeyCode(NSF18FunctionKey);
         case kVK_F19: return NSStringFromMASKeyCode(NSF19FunctionKey);
-        case kVK_Space: return NSStringFromMASKeyCode(0x20);
-        default: return @"";
+        case kVK_Space: return NSStringFromMASKeyCode(kMASShortcutSpaceFunctionKey);
+        case kVK_Escape: return NSStringFromMASKeyCode(kMASShortcutEscapeFunctionKey);
+        case kVK_Delete: return NSStringFromMASKeyCode(NSBackspaceCharacter);
+        case kVK_ForwardDelete: return NSStringFromMASKeyCode(NSDeleteFunctionKey);
+        case kVK_LeftArrow: return NSStringFromMASKeyCode(NSLeftArrowFunctionKey);
+        case kVK_RightArrow: return NSStringFromMASKeyCode(NSRightArrowFunctionKey);
+        case kVK_UpArrow: return NSStringFromMASKeyCode(NSUpArrowFunctionKey);
+        case kVK_DownArrow: return NSStringFromMASKeyCode(NSDownArrowFunctionKey);
+        case kVK_Help: return NSStringFromMASKeyCode(NSHelpFunctionKey);
+        case kVK_Home: return NSStringFromMASKeyCode(NSHomeFunctionKey);
+        case kVK_End: return NSStringFromMASKeyCode(NSEndFunctionKey);
+        case kVK_PageUp: return NSStringFromMASKeyCode(NSPageUpFunctionKey);
+        case kVK_PageDown: return NSStringFromMASKeyCode(NSPageDownFunctionKey);
+        case kVK_Tab: return NSStringFromMASKeyCode(kMASShortcutTabFunctionKey);
+        case kVK_Return: return NSStringFromMASKeyCode(kMASShortcutReturnFunctionKey);
     }
+
+    return keyCodeString.lowercaseString;
 }
 
 - (NSString *)keyCodeString
@@ -110,7 +121,9 @@ static NSString *const MASShortcutModifierFlags = @"ModifierFlags";
         case kVK_RightArrow: return NSStringFromMASKeyCode(kMASShortcutGlyphRightArrow);
         case kVK_UpArrow: return NSStringFromMASKeyCode(kMASShortcutGlyphUpArrow);
         case kVK_DownArrow: return NSStringFromMASKeyCode(kMASShortcutGlyphDownArrow);
-        case kVK_Help: return NSStringFromMASKeyCode(kMASShortcutGlyphHelp);
+        case kVK_Help: return NSStringFromMASKeyCode(kMASShortcutGlyphHelp); // Insert
+        case kVK_Home: return NSStringFromMASKeyCode(kMASShortcutGlyphNorthwestArrow);
+        case kVK_End: return NSStringFromMASKeyCode(kMASShortcutGlyphSoutheastArrow);
         case kVK_PageUp: return NSStringFromMASKeyCode(kMASShortcutGlyphPageUp);
         case kVK_PageDown: return NSStringFromMASKeyCode(kMASShortcutGlyphPageDown);
         case kVK_Tab: return NSStringFromMASKeyCode(kMASShortcutGlyphTabRight);
@@ -135,10 +148,6 @@ static NSString *const MASShortcutModifierFlags = @"ModifierFlags";
         case kVK_ANSI_KeypadEnter: return NSStringFromMASKeyCode(kMASShortcutGlyphReturn);
         case kVK_ANSI_KeypadMinus: return @"-";
         case kVK_ANSI_KeypadEquals: return @"=";
-            
-        // Hardcode
-        case 119: return NSStringFromMASKeyCode(kMASShortcutGlyphSoutheastArrow);
-        case 115: return NSStringFromMASKeyCode(kMASShortcutGlyphNorthwestArrow);
     }
     
     // Everything else should be printable so look it up in the current ASCII capable keyboard layout


### PR DESCRIPTION
My use case involves setting `keyCodeStringForKeyEquivalent`s of `MASShortcut`s directly into `NSButton`s' `keyEquivalent` properties.

<img width="1014" alt="Screenshot 2021-10-11 AM 12 29 14" src="https://user-images.githubusercontent.com/8158163/136704918-a1d3ad6b-3429-4d34-9051-4df3bb31dd64.png">

`MASShortcut` class can help simplify display logic for special function keys such as "←". However, I found that `keyCodeStringForKeyEquivalent`s of functions keys such as arrow, backspace, return and alike returns empty.

This PR:
1. Removes `keyCodeString.length <= 1` testing in `-[MASShortcut keyCodeStringForKeyEquivalent]` since only `keyCodeString`s of F keys contains multiple charactes.
2. Makes `keyCodeStringForKeyEquivalent` aligned up with `keyCodeString`. All keys are tested and should work, **except for space and tab**.
    * Using space for keyEquivalent is not supported by AppKit, see [here](https://stackoverflow.com/questions/11155239/nsmenuitem-keyequivalent-space-bug).
    * Currently, tabs cannot be recorded by `MASShortcutView`.
3. Adds `kMASShortcutFuctionKey` definitions for missing `NS*FunctionKey`s outside of Unicode private range. Although definitions some keys (like `NSBackspaceCharacter`) can be found elsewhere in AppKit headers, this helps to make code  consistent.
4. Replaces hared-coded values (119 and 115) into (`kVK_Home` and `kVK_End`) and adds comment for `kVK_Help`, which actually represents for 'Insert' on most keyboards.