### PR TITLE
Allow 'Services' menu items to pass the shortcut validation.

### DIFF
--- a/Framework/Model/MASShortcutValidator.h
+++ b/Framework/Model/MASShortcutValidator.h
@@ -20,6 +20,17 @@
 */
 @property(assign) BOOL allowAnyShortcutWithOptionModifier;
 
+/**
+ Set to `YES` if you want to accept shortcuts that override the Services menu
+ item.
+
+ `NO` by default. Set to `YES` to allow shortcuts to override key equivalents of
+ Services menu items. This can prevent users from being confused when they can't
+ find the conflicting menu item since menu items in the Services menu are not
+ always visible.
+*/
+@property(assign) BOOL allowOverridingServicesShortcut;
+
 + (instancetype) sharedValidator;
 
 - (BOOL) isShortcutValid: (MASShortcut*) shortcut;

--- a/Framework/Model/MASShortcutValidator.m
+++ b/Framework/Model/MASShortcutValidator.m
@@ -52,6 +52,10 @@
 
 - (BOOL) isShortcut: (MASShortcut*) shortcut alreadyTakenInMenu: (NSMenu*) menu explanation: (NSString**) explanation
 {
+    if (self.allowOverridingServicesShortcut && menu == [NSApp servicesMenu]) {
+        return NO;
+    }
+
     NSString *keyEquivalent = [shortcut keyCodeStringForKeyEquivalent];
     NSEventModifierFlags flags = [shortcut modifierFlags];
 


### PR DESCRIPTION
Shift+Cmd+A is a default shortcut for a core functionary of our app.

I got an issue from our user that if they set it to another shortcut, then clear it, they'll not be able to set it back. 

<img width="395" alt="Screen Shot 2022-04-13 at 21 05 09" src="https://user-images.githubusercontent.com/8158163/163186446-8a2e7fae-b360-4bfa-adb6-6b4d9d86acca.png">

This PR excludes `-[NSApp servicesMenu]` from `-[MASShortcutValidator isShortcut:alreadyTakenInMenu:explanation:]` check. Which prevents the user from being confused when they can't find the conflicting menu item.
It's generally fine to have a custom shortcut that overrides the 'Services' shortcut.