### PR TITLE
Add fn key to `MASPickCocoaModifiers`

### DIFF
--- a/Framework/Model/MASKeyCodes.h
+++ b/Framework/Model/MASKeyCodes.h
@@ -39,6 +39,11 @@ NS_INLINE NSString* NSStringFromMASKeyCode(unsigned short ch)
 
 NS_INLINE NSUInteger MASPickCocoaModifiers(NSUInteger flags)
 {
+    return (flags & (NSEventModifierFlagControl | NSEventModifierFlagShift | NSEventModifierFlagOption | NSEventModifierFlagCommand));
+}
+
+NS_INLINE NSUInteger MASPickAllCocoaModifiers(NSUInteger flags)
+{
     return (flags & (NSEventModifierFlagControl | NSEventModifierFlagShift | NSEventModifierFlagOption | NSEventModifierFlagCommand | NSEventModifierFlagFunction));
 }
 

--- a/Framework/Model/MASKeyCodes.h
+++ b/Framework/Model/MASKeyCodes.h
@@ -39,7 +39,7 @@ NS_INLINE NSString* NSStringFromMASKeyCode(unsigned short ch)
 
 NS_INLINE NSUInteger MASPickCocoaModifiers(NSUInteger flags)
 {
-    return (flags & (NSEventModifierFlagControl | NSEventModifierFlagShift | NSEventModifierFlagOption | NSEventModifierFlagCommand));
+    return (flags & (NSEventModifierFlagControl | NSEventModifierFlagShift | NSEventModifierFlagOption | NSEventModifierFlagCommand | NSEventModifierFlagFunction));
 }
 
 NS_INLINE UInt32 MASCarbonModifiersFromCocoaModifiers(NSUInteger cocoaFlags)

--- a/Framework/Model/MASKeyCodes.h
+++ b/Framework/Model/MASKeyCodes.h
@@ -42,7 +42,9 @@ NS_INLINE NSUInteger MASPickCocoaModifiers(NSUInteger flags)
     return (flags & (NSEventModifierFlagControl | NSEventModifierFlagShift | NSEventModifierFlagOption | NSEventModifierFlagCommand));
 }
 
-NS_INLINE NSUInteger MASPickAllCocoaModifiers(NSUInteger flags)
+// Used in `-[MASShortcutValidator isShortcut:alreadyTakenInMenu:explanation:]`.
+// This prevents incorrectly detecting an overlap with any shortcuts using the `fn` key.
+NS_INLINE NSUInteger MASPickModifiersIncludingFn(NSUInteger flags)
 {
     return (flags & (NSEventModifierFlagControl | NSEventModifierFlagShift | NSEventModifierFlagOption | NSEventModifierFlagCommand | NSEventModifierFlagFunction));
 }

--- a/Framework/Model/MASShortcutValidator.m
+++ b/Framework/Model/MASShortcutValidator.m
@@ -62,13 +62,13 @@
     for (NSMenuItem *menuItem in menu.itemArray) {
         if (menuItem.hasSubmenu && [self isShortcut:shortcut alreadyTakenInMenu:[menuItem submenu] explanation:explanation]) return YES;
         
-        BOOL equalFlags = (MASPickAllCocoaModifiers(menuItem.keyEquivalentModifierMask) == flags);
+        BOOL equalFlags = (MASPickModifiersIncludingFn(menuItem.keyEquivalentModifierMask) == flags);
         BOOL equalHotkeyLowercase = [menuItem.keyEquivalent.lowercaseString isEqualToString:keyEquivalent];
         
         // Check if the cases are different, we know ours is lower and that shift is included in our modifiers
         // If theirs is capitol, we need to add shift to their modifiers
         if (equalHotkeyLowercase && ![menuItem.keyEquivalent isEqualToString:keyEquivalent]) {
-            equalFlags = (MASPickAllCocoaModifiers(menuItem.keyEquivalentModifierMask | NSEventModifierFlagShift) == flags);
+            equalFlags = (MASPickModifiersIncludingFn(menuItem.keyEquivalentModifierMask | NSEventModifierFlagShift) == flags);
         }
         
         if (equalFlags && equalHotkeyLowercase) {

--- a/Framework/Model/MASShortcutValidator.m
+++ b/Framework/Model/MASShortcutValidator.m
@@ -62,13 +62,13 @@
     for (NSMenuItem *menuItem in menu.itemArray) {
         if (menuItem.hasSubmenu && [self isShortcut:shortcut alreadyTakenInMenu:[menuItem submenu] explanation:explanation]) return YES;
         
-        BOOL equalFlags = (MASPickCocoaModifiers(menuItem.keyEquivalentModifierMask) == flags);
+        BOOL equalFlags = (MASPickAllCocoaModifiers(menuItem.keyEquivalentModifierMask) == flags);
         BOOL equalHotkeyLowercase = [menuItem.keyEquivalent.lowercaseString isEqualToString:keyEquivalent];
         
         // Check if the cases are different, we know ours is lower and that shift is included in our modifiers
         // If theirs is capitol, we need to add shift to their modifiers
         if (equalHotkeyLowercase && ![menuItem.keyEquivalent isEqualToString:keyEquivalent]) {
-            equalFlags = (MASPickCocoaModifiers(menuItem.keyEquivalentModifierMask | NSEventModifierFlagShift) == flags);
+            equalFlags = (MASPickAllCocoaModifiers(menuItem.keyEquivalentModifierMask | NSEventModifierFlagShift) == flags);
         }
         
         if (equalFlags && equalHotkeyLowercase) {


### PR DESCRIPTION
I uncovered a very strange bug in an app I'm working on, which allows single-key shortcuts by using a custom validator; however, my validator still calls `-[MASShortcutValidator isShortcutAlreadyTakenBySystem:explanation:]`.

It turns out that if you open the "View" (or "Window"?) menu and close it, from that point on MASShortcut will start recognizing the "Enter Full Screen" menu item, which has a shortcut of fn-F (stylized as globe-F). Then, when calling `-[MASShortcutValidator isShortcutAlreadyTakenBySystem:explanation:]`, `MASPickCocoaModifiers` drops the `NSEventModifierFlagFunction` mask, which makes it appear the same as the bare "F" key, and the user is prohibited from selecting "F" as a shortcut.

I imagine this would also be an issue if the user assigned any custom shortcuts to a menu item (from System Preferences > Keyboard) that include the fn key, e.g. fn-cmd-shift-A would conflict with cmd-shift-A.

This PR fixes the issue by including `NSEventModifierFlagFunction` in the flags returned by `MASPickCocoaModifiers`.